### PR TITLE
https links in .gitmodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "libcross2d"]
 	path = libcross2d
-	url = git@github.com:Cpasjuste/libcross2d.git
+	url = https://github.com/Cpasjuste/libcross2d.git
 [submodule "mpv"]
 	path = mpv
-	url = git@github.com:Cpasjuste/mpv.git
+	url = https://github.com/Cpasjuste/mpv.git


### PR DESCRIPTION
Update urls in .gitmodules to https instead of ssh, so user shouldn't be logged in to github to clone it.